### PR TITLE
Truncate the original file before overwriting it

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -98,7 +98,7 @@ namespace Gitpad
 
         static void WriteStringToFile(string path, string fileData, LineEndingType lineType)
         {
-            using(var of = File.OpenWrite(path))
+            using(var of = File.Open(path, FileMode.Create))
             {
                 var buf = Encoding.UTF8.GetBytes(ForceLineEndings(fileData, lineType));
                 of.Write(buf, 0, buf.Length);


### PR DESCRIPTION
If you opened a file that contained "AAAAA" and edited it to contain "BBB",
GitPad would create a file that contained "BBBAA". Now the original file gets
completely truncated before the new contents are laid down, so you'll end up
with "BBB" as expected.
