### PR TITLE
Remove unnecessary console spew

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -152,7 +152,6 @@ namespace Gitpad
                     throw new Exception("GetTokenInformation failed");
                 }
 
-                Console.WriteLine(elevationType);
                 return (elevationType == TOKEN_ELEVATION_TYPE.TokenElevationTypeFull);
             }
             finally


### PR DESCRIPTION
Every time I ran GitPad I would see "TokenElevationTypeLimited" in the console.
