### PR TITLE
ensure notepad.exe is always used as the editor

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -66,8 +66,9 @@ namespace Gitpad
                 goto bail;
             }
 
-            var psi = new ProcessStartInfo(path)
+            var psi = new ProcessStartInfo("notepad.exe")
             {
+                Arguments = path,
                 WindowStyle = ProcessWindowStyle.Normal,
                 UseShellExecute = true,
             };


### PR DESCRIPTION
I'm not sure whether this change fixes a bug, or whether the behaviour is by design, so feel free to not merge it if that's the case.

I noticed that GitPad stopped using notepad when I changed my default editor for txt files to something else. I still wanted GitPad to open with notepad but I found it was opening the other editor.

(The reason I can't just use this editor instead is because it's the single-instance kind where, if there's an existing process, all it does is communicate which file to open to that process and then exit immediately. Which to git meant I had finished editing, making it impossible to use.)

Anyway, I fixed that by running notepad.exe with the file as the argument rather than just the file itself. 
