### PR TITLE
Editor reuse crash fix

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -73,11 +73,24 @@ namespace Gitpad
             };
 
             var proc = Process.Start(psi);
-            proc.WaitForExit();
-            if (proc.ExitCode != 0)
+
+            // See http://stackoverflow.com/questions/3456383/process-start-returns-null
+            // In case of editor reuse (think VS) we can't block on the process so we only have two options. Either try 
+            // to be clever and monitor the file for changes but it's quite possible that users save their file before 
+            // being done with them so we'll go with the semi-sucky method of showing a message on the console
+            if (proc == null)
             {
-                ret = proc.ExitCode;
-                goto bail;
+                Console.WriteLine("Press enter when you're done editing your commit message, or CTRL+C to abort");
+                Console.ReadLine();
+            }
+            else
+            {
+                proc.WaitForExit();
+                if (proc.ExitCode != 0)
+                {
+                    ret = proc.ExitCode;
+                    goto bail;
+                }
             }
 
             try


### PR DESCRIPTION
If users associate Visual Studio with .txt files we won't get a Process back from Process.Start (since Visual Studio just opens it in a tab).

This PR handles that gracefully by requiring the users to provide the blocking themselves via pressing enter in the console before we capture the commit message.
