### PR TITLE
Don't add new lines to the end of the file every time it's saved

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -165,7 +165,9 @@ namespace Gitpad
                 ret.Append(ending);
             }
 
-            return ret.ToString();
+            // Don't add new lines to the end of the file.
+            string str = ret.ToString();
+            return str.Substring(0, str.Length - ending.Length);
         }
 
         public static unsafe bool IsProcessElevated()


### PR DESCRIPTION
I've noticed over time my config files end up with more and more new lines at the end, and I suspected it was GitPad's doing but I didn't get a chance to investigate until now.

[Program.cs:161](https://github.com/crdx/GitPad/blob/ca3c0eb0e77dd8361fd8c23401e0a274a0d7ba56/Program.cs#L161)

``` cs
foreach (var line in fileData.Split('\n'))
{
    var fixedLine = line.Replace("\r", "");
    ret.Append(fixedLine);
    ret.Append(ending);
}
```

The resulting file contents have a trailing instance of whatever line ending character is being used, and this is then written to the file. So every time you use GitPad your config files end up with an extra new line. It was simple enough to fix.
