### PR TITLE
Allow GitPad to run elevated when not installing itself

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -31,7 +31,7 @@ namespace Gitpad
                     return -1;
                 }
 
-				if ( MessageBox.Show( "Do you want to use your default text editor as your commit editor?", 
+                if ( MessageBox.Show( "Do you want to use your default text editor as your commit editor?", 
                     "Installing GitPad", MessageBoxButtons.YesNo) != DialogResult.Yes)
                 {
                     return -1;


### PR DESCRIPTION
..so that it is possible to use it from an elevated command prompt for example.

No changes when running it to install: it still refuse to run if elevated in that case
