### PR TITLE
Changed environment variable to no longer use ~

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -48,7 +48,7 @@ namespace Gitpad
                 var dest = new FileInfo(Environment.ExpandEnvironmentVariables(@"%AppData%\GitPad\GitPad.exe"));
                 File.Copy(Assembly.GetExecutingAssembly().Location, dest.FullName, true);
 
-                Environment.SetEnvironmentVariable("EDITOR", "~/AppData/Roaming/GitPad/GitPad.exe", EnvironmentVariableTarget.User);
+                Environment.SetEnvironmentVariable("EDITOR", dest.FullName.Replace('\\', '/'), EnvironmentVariableTarget.User);
                 return 0;
             }
 


### PR DESCRIPTION
AppData isn't necessarily a directory underneath $Home in some
environments. Changed to use the DirectoryInfo.DirectoryName instead and
reverse the slashes.

Should fix https://github.com/github/GitPad/issues/18
