### PR TITLE
Use tilde path for environment variable

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -47,7 +47,7 @@ namespace Gitpad
                 var dest = new FileInfo(Environment.ExpandEnvironmentVariables(@"%AppData%\GitPad\GitPad.exe"));
                 File.Copy(Assembly.GetExecutingAssembly().Location, dest.FullName, true);
 
-                Environment.SetEnvironmentVariable("EDITOR", dest.FullName.Replace('\\', '/'), EnvironmentVariableTarget.User);
+                Environment.SetEnvironmentVariable("EDITOR", "~/AppData/Roaming/GitPad/GitPad.exe", EnvironmentVariableTarget.User);
                 return 0;
             }
 


### PR DESCRIPTION
This is more resilient to issues such as spaces in user name.
Fixes #29